### PR TITLE
WIFI-13523: Fix: Support linking of resources and configs through POST request. (#5)

### DIFF
--- a/src/RESTAPI/RESTAPI_db_helpers.h
+++ b/src/RESTAPI/RESTAPI_db_helpers.h
@@ -390,6 +390,13 @@ namespace OpenWifi {
 	}
 
 	template <typename db_type, typename Member>
+	void AddMembership(db_type &DB, Member T, const Types::UUIDvec_t &Obj, const std::string &Id) {
+		for (const auto &i : Obj) {
+			AddMembership(DB, T, i, Id);
+		}
+	}
+
+	template <typename db_type, typename Member>
 	void ManageMembership(db_type &DB, Member T, const std::string &From, const std::string &To,
 						  const std::string &Id) {
 		RemoveMembership(DB, T, From, Id);


### PR DESCRIPTION
# Description

This was supported in the PUT request, but missing in POST for some reason. Now if you link the variables when creating the config, you won't be able to delete the variable if the config exists.

https://telecominfraproject.atlassian.net/browse/WIFI-13523

# Summary of changes:

- Modified code to error when deleting variables incorrectly.