### PR TITLE
fix: modified code to use proper fingerprint defintion

### DIFF
--- a/src/framework/ConfigurationValidator.cpp
+++ b/src/framework/ConfigurationValidator.cpp
@@ -3769,7 +3769,7 @@ static std::string DefaultAPSchema = R"foo(
                         "final",
                         "raw-data"
                     ],
-                    "default": "always"
+                    "default": "final"
                 },
                 "minimum-age": {
                     "description": "The minimum age a fingerprint must have before it is reported.",

--- a/src/framework/ConfigurationValidator.cpp
+++ b/src/framework/ConfigurationValidator.cpp
@@ -3758,8 +3758,40 @@ static std::string DefaultAPSchema = R"foo(
             }
         },
         "service.fingerprint": {
-            "description": "This section option enables fingerprinting.",
-            "type": "boolean"
+            "description": "This section can be used to configure device fingerprinting.",
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "description": "Enable this option if you would like to enable the MDNS server on the unit.",
+                    "type": "string",
+                    "enum": [
+                        "polled",
+                        "final",
+                        "raw-data"
+                    ],
+                    "default": "always"
+                },
+                "minimum-age": {
+                    "description": "The minimum age a fingerprint must have before it is reported.",
+                    "type": "number",
+                    "default": 60
+                },
+                "maximum-age": {
+                    "description": "The age at which fingerprints get flushed from the local state.",
+                    "type": "number",
+                    "default": 60
+                },
+                "periodicity": {
+                    "description": "This value defines the period at which entries get reported.",
+                    "type": "number",
+                    "default": 600
+                },
+                "allow-wan": {
+                    "description": "Allow fingerprinting devices found on the WAN port.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
         },
         "service": {
             "description": "This section describes all of the services that may be present on the AP. Each service is then referenced via its name inside an interface, ssid, ...",


### PR DESCRIPTION
# Description

Incorrect `fingerprint` definition was checked in. Needs to be updated.
More details in:
https://telecominfraproject.atlassian.net/browse/WIFI-431

NOTE: This port of https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/pull/355

# Summary of changes:
- Modified code to use proper definition of fingerprint service.