### PR TITLE
WIFI-14257: fix can not get corrent deviceTypes from AppServiceRegistry

### DIFF
--- a/src/framework/AppServiceRegistry.h
+++ b/src/framework/AppServiceRegistry.h
@@ -67,9 +67,9 @@ namespace OpenWifi {
 
         bool Get(const char *key, std::vector<std::string> &Value) {
             if(Registry_->has(key) && !Registry_->isNull(key) && Registry_->isArray(key)) {
-                auto Arr = Registry_->get(key);
-                for(const auto &v:Arr) {
-                    Value.emplace_back(v);
+                auto pArr = Registry_->getArray(key);
+                for(const auto &v : *pArr) {
+                    Value.emplace_back(v.toString());
                 }
                 return true;
             }


### PR DESCRIPTION
# Description
fix can not get corrent deviceTypes from AppServiceRegistry

Copy of this PR: https://github.com/Telecominfraproject/wlan-cloud-owprov/pull/112